### PR TITLE
[#3] refactor: isolate the app routes

### DIFF
--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"log"
 	"log/slog"
 	"net/http"
 	"os"
@@ -38,30 +37,11 @@ func main() {
 		logger: logger,
 	}
 
-	mux := http.NewServeMux()
+	logger.Info("starting server", "addr", *addr)
 
-	// Create a file server which serves files out of the "./ui/static" directory.
-	// Note that the path given to the http.Dir function is relative to the project directory root.
-	fileServer := http.FileServer(http.Dir("./ui/static/"))
-
-	// Use the mux.Handle() function to register the file server as the handler for all URL paths that start with "/static/".
-	// For matching paths, we strip the "/static" prefix before the request reaches the file server.
-	mux.Handle("GET /static/", http.StripPrefix("/static", fileServer))
-
-	// Swap the route declarations to use the application struct's methods as the handler functions.
-	mux.HandleFunc("GET /{$}", app.home)
-	mux.HandleFunc("GET /snippet/view/{id}", app.snippetView)
-	mux.HandleFunc("GET /snippet/create", app.snippetCreate)
-	mux.HandleFunc("POST /snippet/create", app.snippetCreatePost)
-
-	// The value returned from the flag.String() function is a pointer to the flag value, not the value itself.
-	// So in this code, that means the addr variable is actually a pointer,
-	// and we need to dereference it (i.e. prefix it with the * symbol) before using it.
-	// Note that we're using the log.Printf() function to interpolate the address with the log message.
-	log.Printf("starting server on %s", *addr)
-
-	// And we pass the dereferenced addr pointer to http.ListenAndServe() too.
-	err := http.ListenAndServe(*addr, mux)
+	// Call the new app.routes() method to get the servemux containing our routes,
+	// and pass that to http.ListenAndServe().
+	err := http.ListenAndServe(*addr, app.routes())
 
 	// And we also use the Error() method to log any error message returned by
 	// http.ListenAndServe() at Error severity (with no additional attributes),

--- a/cmd/web/routes.go
+++ b/cmd/web/routes.go
@@ -1,0 +1,24 @@
+package main
+
+import "net/http"
+
+// the routes() method return a servermux containing our application routes
+func (app *application) routes() *http.ServeMux {
+	mux := http.NewServeMux()
+
+	// Create a file server which serves files out of the "./ui/static" directory.
+	// Note that the path given to the http.Dir function is relative to the project directory root.
+	fileServer := http.FileServer(http.Dir("./ui/static/"))
+
+	// Use the mux.Handle() function to register the file server as the handler for all URL paths that start with "/static/".
+	// For matching paths, we strip the "/static" prefix before the request reaches the file server.
+	mux.Handle("GET /static/", http.StripPrefix("/static", fileServer))
+
+	// Swap the route declarations to use the application struct's methods as the handler functions.
+	mux.HandleFunc("GET /{$}", app.home)
+	mux.HandleFunc("GET /snippet/view/{id}", app.snippetView)
+	mux.HandleFunc("GET /snippet/create", app.snippetCreate)
+	mux.HandleFunc("POST /snippet/create", app.snippetCreatePost)
+
+	return mux
+}


### PR DESCRIPTION
The routes for our app are now isolated and encapsulated in the app.routes() method, and the responsibilities of our main() func are limited to:
- Parsing the runtime config setting for the app
- Establishing the dependencies for the handlers
- Running the HTTP server